### PR TITLE
link Zig code from iOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *Builder) !void {
     const exe = b.addExecutable("app", null);
     b.default_step.dependOn(&exe.step);
     exe.addCSourceFile("main.m", &[0][]const u8{});
+    exe.addPackagePath("zigCode", "zig_code.zig");
     exe.setBuildMode(mode);
     exe.setTarget(target);
     exe.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -2,14 +2,19 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Builder = std.build.Builder;
 
+const zigIsMain = true;
+
 pub fn build(b: *Builder) !void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
 
-    const exe = b.addExecutable("app", null);
+    const exePath = if (zigIsMain) "zig_code.zig" else null;
+    const exe = b.addExecutable("app", exePath);
     b.default_step.dependOn(&exe.step);
     exe.addCSourceFile("main.m", &[0][]const u8{});
-    exe.addPackagePath("zigCode", "zig_code.zig");
+    if (!zigIsMain) {
+        exe.addPackagePath("zigCode", "zig_code.zig");
+    }
     exe.setBuildMode(mode);
     exe.setTarget(target);
     exe.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -8,8 +8,8 @@ pub fn build(b: *Builder) !void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
 
-    const exePath = if (zigIsMain) "zig_code.zig" else null;
-    const exe = b.addExecutable("app", exePath);
+    const rootSrcPath = if (zigIsMain) "zig_code.zig" else null;
+    const exe = b.addExecutable("app", rootSrcPath);
     b.default_step.dependOn(&exe.step);
     exe.addCSourceFile("main.m", &[0][]const u8{});
     if (!zigIsMain) {

--- a/main.m
+++ b/main.m
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+#include "zig_code.h"
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 @property (strong, nonatomic) UIWindow *window;
 @end
@@ -20,6 +22,8 @@
   self.window.rootViewController = viewController;
 
   [self.window makeKeyAndVisible];
+
+  zigFoo(420);
 
   return YES;
 }

--- a/zig_code.h
+++ b/zig_code.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void zigFoo(int bar);

--- a/zig_code.zig
+++ b/zig_code.zig
@@ -1,0 +1,4 @@
+extern fn zigFoo(bar: c_int) c_void
+{
+	// something
+}

--- a/zig_code.zig
+++ b/zig_code.zig
@@ -1,4 +1,7 @@
-extern fn zigFoo(bar: c_int) c_void
+export fn zigFoo(bar: c_int) void
 {
-	// something
+    _ = bar;
+    // something
 }
+
+pub extern fn main(c_int, [*c]i8) c_int; // for when zig is main


### PR DESCRIPTION
*EDITx2: nevermind, same link errors here as option 1 below. EDIT: Currently trying another way ~~and it seems to be working.~~ I made `zig_code.zig` the root src for the executable, wrote a classic Zig main function, then called into the iOS main function (renamed to `iosMain`) from Zig. ~~Not sure what's different here, but it links. Testing if the app still works...~~*

Hello! Not really looking to get this merged, just trying to figure out how to call and link Zig code into my iOS app. I'm testing this with the Zig compiler built from your changes in https://github.com/ziglang/zig/pull/9532. Tried to link in Zig code in 2 ways, and I get different link errors for each:

### option 1
`zigIsMain = true`

Zig package is passed as root src for the executable and has an `extern` main function that should get linked with the one in `main.m`.

errors:
```
warning(link): directory not found for '-L/usr/local/lib'
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_kernel.dylib
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_platform.dylib
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_pthread.dylib
error(link): undefined reference to symbol '___error'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_close$NOCANCEL'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_fcntl'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_fstat$INODE64'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_mach_absolute_time'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_mach_timebase_info'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_mmap'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_munmap'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_openat'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_pthread_mutex_lock'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_pthread_mutex_unlock'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_pthread_threadid_np'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_read'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_sched_yield'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error(link): undefined reference to symbol '_write'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/c5d1cba50ec2a92e12052f5c1e19941b/app.o'
error: UndefinedSymbolReference
```

### option 2
`zigIsMain = false`

Executable has `null` root src, and I add the Zig code later using `addPackagePath`. No need for extern main in the Zig file for this one, but shouldn't do any harm either. I don't think the Zig code is being compiled at all here, because I can type whatever in the code and get no compile errors... so maybe if it was compiled, I'd get the same errors as option 1.

errors:
```
warning(link): directory not found for '-L/usr/local/lib'
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_kernel.dylib
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_platform.dylib
warning(dylib): unable to resolve dependency /usr/lib/system/libsystem_pthread.dylib
error(link): undefined reference to symbol '_zigFoo'
error(link):   first referenced in '/Users/patio/Documents/zig-ios-example/zig-cache/o/512ece8622dfd913e6dad91cd24f0611/main.o'
error: UndefinedSymbolReference
```

### =========================================

I've been getting the `warning(...)` lines in all cases, even before trying to add Zig code, so not sure what that's about... that might be a hint for the link errors in option 1 - for some reason pthread and other posix functions aren't getting linked. All targets I've tried so far seem to fail - `x86_64-ios-simulator`, `aarch64-ios-simulator`, and `aarch64-ios` (I'm on an `x86_64` mac running the simulator, so mostly been testing `x86_64-ios-simulator`).