### PR TITLE
Tweak example to call UIApplicationMain from Zig directly

### DIFF
--- a/AppDelegate.h
+++ b/AppDelegate.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end
+

--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -1,0 +1,25 @@
+#import "AppDelegate.h"
+#import <UIKit/UIKit.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(id)options {
+  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
+  self.window = [[UIWindow alloc] initWithFrame:mainScreenBounds];
+  UIViewController *viewController = [[UIViewController alloc] init];
+  viewController.view.backgroundColor = [UIColor whiteColor];
+  viewController.view.frame = mainScreenBounds;
+
+  UILabel *label = [[UILabel alloc] initWithFrame:mainScreenBounds];
+  [label setText:@"Wow! I was built with Zig!"];
+  [viewController.view addSubview: label];
+
+  self.window.rootViewController = viewController;
+
+  [self.window makeKeyAndVisible];
+
+  return YES;
+}
+
+@end
+

--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -1,6 +1,8 @@
 #import "AppDelegate.h"
 #import <UIKit/UIKit.h>
 
+char* dummyMsg();
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(id)options {
@@ -10,8 +12,10 @@
   viewController.view.backgroundColor = [UIColor whiteColor];
   viewController.view.frame = mainScreenBounds;
 
+  NSString* msg = [NSString stringWithUTF8String:dummyMsg()];
+
   UILabel *label = [[UILabel alloc] initWithFrame:mainScreenBounds];
-  [label setText:@"Wow! I was built with Zig!"];
+  [label setText:msg];
   [viewController.view addSubview: label];
 
   self.window.rootViewController = viewController;

--- a/AppMain.m
+++ b/AppMain.m
@@ -1,7 +1,7 @@
 #import "AppDelegate.h"
 #import <UIKit/UIKit.h>
 
-int main(int argc, char *argv[]) {
+int appMain(int argc, char *argv[]) {
   @autoreleasepool {
     return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
   }

--- a/AppMain.m
+++ b/AppMain.m
@@ -1,8 +1,8 @@
 #import "AppDelegate.h"
 #import <UIKit/UIKit.h>
 
-int appMain(int argc, char *argv[]) {
+int appMain() {
   @autoreleasepool {
-    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    return UIApplicationMain(0, nil, nil, NSStringFromClass([AppDelegate class]));
   }
 }

--- a/build.zig
+++ b/build.zig
@@ -6,10 +6,10 @@ pub fn build(b: *Builder) !void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
 
-    const exe = b.addExecutable("app", null);
+    const exe = b.addExecutable("app", "main.zig");
     b.default_step.dependOn(&exe.step);
     exe.addIncludeDir(".");
-    exe.addCSourceFiles(&[_][]const u8{ "main.m", "AppDelegate.m" }, &[0][]const u8{});
+    exe.addCSourceFiles(&[_][]const u8{ "AppMain.m", "AppDelegate.m" }, &[0][]const u8{});
     exe.setBuildMode(mode);
     exe.setTarget(target);
     exe.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,8 @@ pub fn build(b: *Builder) !void {
 
     const exe = b.addExecutable("app", null);
     b.default_step.dependOn(&exe.step);
-    exe.addCSourceFile("main.m", &[0][]const u8{});
+    exe.addIncludeDir(".");
+    exe.addCSourceFiles(&[_][]const u8{ "main.m", "AppDelegate.m" }, &[0][]const u8{});
     exe.setBuildMode(mode);
     exe.setTarget(target);
     exe.linkLibC();

--- a/main.m
+++ b/main.m
@@ -1,30 +1,5 @@
+#import "AppDelegate.h"
 #import <UIKit/UIKit.h>
-
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
-@property (strong, nonatomic) UIWindow *window;
-@end
-
-@implementation AppDelegate
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(id)options {
-  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
-  self.window = [[UIWindow alloc] initWithFrame:mainScreenBounds];
-  UIViewController *viewController = [[UIViewController alloc] init];
-  viewController.view.backgroundColor = [UIColor whiteColor];
-  viewController.view.frame = mainScreenBounds;
-
-  UILabel *label = [[UILabel alloc] initWithFrame:mainScreenBounds];
-  [label setText:@"Wow! I was built with Zig!"];
-  [viewController.view addSubview: label];
-
-  self.window.rootViewController = viewController;
-
-  [self.window makeKeyAndVisible];
-
-  return YES;
-}
-
-@end
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {

--- a/main.zig
+++ b/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const log = std.log.scoped(.app);
+
+extern "c" fn appMain(c_int, *const ?*u8) c_int;
+
+pub fn main() !void {
+    log.warn("spinning up Objective-C main", .{});
+    const args: ?*u8 = null;
+    const code = appMain(0, &args);
+    log.warn("cleaning up; exit code {d}", .{code});
+}

--- a/main.zig
+++ b/main.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
-const log = std.log.scoped(.app);
 
-extern "c" fn appMain(c_int, *const ?*u8) c_int;
+extern "c" fn appMain() isize;
 
-pub fn main() !void {
-    log.warn("spinning up Objective-C main", .{});
-    const args: ?*u8 = null;
-    const code = appMain(0, &args);
-    log.warn("cleaning up; exit code {d}", .{code});
+export fn dummyMsg() [*:0]const u8 {
+    return "Hello from Zig!";
+}
+
+pub fn main() void {
+    _ = appMain();
 }


### PR DESCRIPTION
Also, while at it, let's obtain the label's title by calling Zig's exported function too, why the heck not.

cc @jmrico01 I think this is what you were after with #1? Correct me if I'm wrong please. Also, the linking errors you were seeing are now solved in the Zig's branch ziglang/zig#9532.