### PR TITLE
run on latest zig with a little help of Xcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zig-cache
 zig-out
+build

--- a/MadeWithZig.xcodeproj/project.pbxproj
+++ b/MadeWithZig.xcodeproj/project.pbxproj
@@ -1,0 +1,531 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		653C80652AB22132004FEA69 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 653C80632AB22132004FEA69 /* AppDelegate.m */; };
+		653C80662AB22132004FEA69 /* AppMain.m in Sources */ = {isa = PBXBuildFile; fileRef = 653C80642AB22132004FEA69 /* AppMain.m */; };
+		653C80682AB2216A004FEA69 /* libmain.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 653C80672AB2216A004FEA69 /* libmain.a */; };
+		653C806A2AB221FB004FEA69 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 653C80692AB221FB004FEA69 /* Main.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		653C80462AB220FA004FEA69 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 653C80222AB220F9004FEA69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 653C80292AB220F9004FEA69;
+			remoteInfo = MadeWithZig;
+		};
+		653C80502AB220FA004FEA69 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 653C80222AB220F9004FEA69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 653C80292AB220F9004FEA69;
+			remoteInfo = MadeWithZig;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		653C802A2AB220F9004FEA69 /* MadeWithZig.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MadeWithZig.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		653C80452AB220FA004FEA69 /* MadeWithZigTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MadeWithZigTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		653C804F2AB220FA004FEA69 /* MadeWithZigUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MadeWithZigUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		653C80622AB22132004FEA69 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		653C80632AB22132004FEA69 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		653C80642AB22132004FEA69 /* AppMain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppMain.m; sourceTree = "<group>"; };
+		653C80672AB2216A004FEA69 /* libmain.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmain.a; path = "zig-out/lib/libmain.a"; sourceTree = "<group>"; };
+		653C80692AB221FB004FEA69 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		653C80272AB220F9004FEA69 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				653C80682AB2216A004FEA69 /* libmain.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C80422AB220FA004FEA69 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C804C2AB220FA004FEA69 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		653C80212AB220F9004FEA69 = {
+			isa = PBXGroup;
+			children = (
+				653C80692AB221FB004FEA69 /* Main.storyboard */,
+				653C80672AB2216A004FEA69 /* libmain.a */,
+				653C80622AB22132004FEA69 /* AppDelegate.h */,
+				653C80632AB22132004FEA69 /* AppDelegate.m */,
+				653C80642AB22132004FEA69 /* AppMain.m */,
+				653C802B2AB220F9004FEA69 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		653C802B2AB220F9004FEA69 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				653C802A2AB220F9004FEA69 /* MadeWithZig.app */,
+				653C80452AB220FA004FEA69 /* MadeWithZigTests.xctest */,
+				653C804F2AB220FA004FEA69 /* MadeWithZigUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		653C80292AB220F9004FEA69 /* MadeWithZig */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 653C80592AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZig" */;
+			buildPhases = (
+				653C80262AB220F9004FEA69 /* Sources */,
+				653C80272AB220F9004FEA69 /* Frameworks */,
+				653C80282AB220F9004FEA69 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MadeWithZig;
+			productName = MadeWithZig;
+			productReference = 653C802A2AB220F9004FEA69 /* MadeWithZig.app */;
+			productType = "com.apple.product-type.application";
+		};
+		653C80442AB220FA004FEA69 /* MadeWithZigTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 653C805C2AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZigTests" */;
+			buildPhases = (
+				653C80412AB220FA004FEA69 /* Sources */,
+				653C80422AB220FA004FEA69 /* Frameworks */,
+				653C80432AB220FA004FEA69 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				653C80472AB220FA004FEA69 /* PBXTargetDependency */,
+			);
+			name = MadeWithZigTests;
+			productName = MadeWithZigTests;
+			productReference = 653C80452AB220FA004FEA69 /* MadeWithZigTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		653C804E2AB220FA004FEA69 /* MadeWithZigUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 653C805F2AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZigUITests" */;
+			buildPhases = (
+				653C804B2AB220FA004FEA69 /* Sources */,
+				653C804C2AB220FA004FEA69 /* Frameworks */,
+				653C804D2AB220FA004FEA69 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				653C80512AB220FA004FEA69 /* PBXTargetDependency */,
+			);
+			name = MadeWithZigUITests;
+			productName = MadeWithZigUITests;
+			productReference = 653C804F2AB220FA004FEA69 /* MadeWithZigUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		653C80222AB220F9004FEA69 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					653C80292AB220F9004FEA69 = {
+						CreatedOnToolsVersion = 14.3.1;
+					};
+					653C80442AB220FA004FEA69 = {
+						CreatedOnToolsVersion = 14.3.1;
+						TestTargetID = 653C80292AB220F9004FEA69;
+					};
+					653C804E2AB220FA004FEA69 = {
+						CreatedOnToolsVersion = 14.3.1;
+						TestTargetID = 653C80292AB220F9004FEA69;
+					};
+				};
+			};
+			buildConfigurationList = 653C80252AB220F9004FEA69 /* Build configuration list for PBXProject "MadeWithZig" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 653C80212AB220F9004FEA69;
+			productRefGroup = 653C802B2AB220F9004FEA69 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				653C80292AB220F9004FEA69 /* MadeWithZig */,
+				653C80442AB220FA004FEA69 /* MadeWithZigTests */,
+				653C804E2AB220FA004FEA69 /* MadeWithZigUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		653C80282AB220F9004FEA69 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				653C806A2AB221FB004FEA69 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C80432AB220FA004FEA69 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C804D2AB220FA004FEA69 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		653C80262AB220F9004FEA69 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				653C80662AB22132004FEA69 /* AppMain.m in Sources */,
+				653C80652AB22132004FEA69 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C80412AB220FA004FEA69 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		653C804B2AB220FA004FEA69 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		653C80472AB220FA004FEA69 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 653C80292AB220F9004FEA69 /* MadeWithZig */;
+			targetProxy = 653C80462AB220FA004FEA69 /* PBXContainerItemProxy */;
+		};
+		653C80512AB220FA004FEA69 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 653C80292AB220F9004FEA69 /* MadeWithZig */;
+			targetProxy = 653C80502AB220FA004FEA69 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		653C80572AB220FA004FEA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		653C80582AB220FA004FEA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		653C805A2AB220FA004FEA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/zig-out/lib",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZig;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		653C805B2AB220FA004FEA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/zig-out/lib",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZig;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		653C805D2AB220FA004FEA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZigTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MadeWithZig.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MadeWithZig";
+			};
+			name = Debug;
+		};
+		653C805E2AB220FA004FEA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZigTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MadeWithZig.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MadeWithZig";
+			};
+			name = Release;
+		};
+		653C80602AB220FA004FEA69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZigUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MadeWithZig;
+			};
+			name = Debug;
+		};
+		653C80612AB220FA004FEA69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jakubkonka.MadeWithZigUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MadeWithZig;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		653C80252AB220F9004FEA69 /* Build configuration list for PBXProject "MadeWithZig" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				653C80572AB220FA004FEA69 /* Debug */,
+				653C80582AB220FA004FEA69 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		653C80592AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZig" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				653C805A2AB220FA004FEA69 /* Debug */,
+				653C805B2AB220FA004FEA69 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		653C805C2AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZigTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				653C805D2AB220FA004FEA69 /* Debug */,
+				653C805E2AB220FA004FEA69 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		653C805F2AB220FA004FEA69 /* Build configuration list for PBXNativeTarget "MadeWithZigUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				653C80602AB220FA004FEA69 /* Debug */,
+				653C80612AB220FA004FEA69 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 653C80222AB220F9004FEA69 /* Project object */;
+}

--- a/Main.storyboard
+++ b/Main.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="55" y="-34"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+all: xcbuild xcinstall xcrun
+
+zig-out/lib/libmain.a:
+	zig build -Dtarget=aarch64-ios-simulator
+
+.PHONY: xcbuild
+xcbuild: zig-out/lib/libmain.a
+	xcodebuild -sdk iphonesimulator -arch arm64
+
+.PHONY: xcinstall
+xcinstall:
+	xcrun simctl install booted build/Release-iphonesimulator/MadeWithZig.app
+
+.PHONY: xcrun
+xcrun:
+	xcrun simctl launch booted com.jakubkonka.MadeWithZig
+
+.PHONY: clean
+clean:
+	git clean -fdx

--- a/README.md
+++ b/README.md
@@ -32,16 +32,8 @@ zig build --sysroot <path_to_sdk> -Dtarget=aarch64-ios-simulator
 
 ## Running in iPhone Simulator
 
-Fire up the simulator, and then install the app with
-
 ```
-xcrun simctl install booted zig-out/bin/MadeWithZig.app
-```
-
-You can run the app with
-
-```
-xcrun simctl launch booted madewithzig
+make
 ```
  
 ## WIP: running on an iPhone

--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *Builder) !void {
                 @panic("Couldn't detect native target info");
             const sdk = std.zig.system.darwin.getSdk(b.allocator, target_info.target) orelse
                 @panic("Couldn't detect Apple SDK");
-            break :blk sdk.path;
+            break :blk sdk;
         },
         else => {
             @panic("Missing path to Apple SDK");
@@ -21,33 +21,19 @@ pub fn build(b: *Builder) !void {
     };
     b.sysroot = sdk;
 
-    const exe = b.addExecutable(.{
-        .name = "app",
+    const lib = b.addStaticLibrary(.{
+        .name = "main",
         .root_source_file = .{ .path = "main.zig" },
         .target = target,
         .optimize = optimize,
     });
-    exe.addIncludePath(.{ .cwd_relative = "." });
-    exe.addCSourceFiles(&[_][]const u8{ "AppMain.m", "AppDelegate.m" }, &[0][]const u8{});
-    exe.linkLibC();
-    exe.linkFramework("Foundation");
-    exe.linkFramework("UIKit");
 
-    exe.addSystemFrameworkPath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/System/Library/Frameworks" }) });
-    exe.addSystemIncludePath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/usr/include" }) });
-    exe.addLibraryPath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/usr/lib" }) });
+    lib.addIncludePath(.{ .cwd_relative = "." });
 
-    const install_bin = b.addInstallArtifact(exe, .{});
-    install_bin.step.dependOn(&exe.step);
+    lib.addSystemFrameworkPath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/System/Library/Frameworks" }) });
+    lib.addSystemIncludePath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/usr/include" }) });
+    lib.addLibraryPath(.{ .path = b.pathJoin(&.{ b.sysroot.?, "/usr/lib" }) });
 
-    const install_path = try std.fmt.allocPrint(b.allocator, "{s}/bin/app", .{b.install_path});
-    defer b.allocator.free(install_path);
-
-    const install_exe = b.addInstallFile(.{ .path = install_path }, "bin/MadeWithZig.app/app");
-    const install_plist = b.addInstallFile(.{ .path = "Info.plist" }, "bin/MadeWithZig.app/Info.plist");
-
-    install_plist.step.dependOn(&install_bin.step);
-    install_exe.step.dependOn(&install_plist.step);
-
-    b.default_step.dependOn(&install_exe.step);
+    const install_lib = b.addInstallArtifact(lib, .{});
+    b.default_step.dependOn(&install_lib.step);
 }


### PR DESCRIPTION
Instead of building a spartan executable and .app, make static lib with zig and then get some help from Xcode (addresses #5)

Maybe the xcode files could be generated or replaced with something else?

(I couldn't get the original main to run on a simulator before this commit)

tested on 0.12.0-dev.312+cb6201715